### PR TITLE
Add tabbed windows (such as for Sphere)

### DIFF
--- a/shell/index.html
+++ b/shell/index.html
@@ -11,7 +11,7 @@
     <head>
         <title>LiveG gShell Environment</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <meta http-equiv="Content-Security-Policy" content="default-src gshell://*">
+        <meta http-equiv="Content-Security-Policy" content="default-src gshell://*; img-src * gshell://*">
         <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
         <link rel="stylesheet" href="gshell://lib/adaptui/src/adaptui.css">
         <link rel="stylesheet" href="gshell://style.css">

--- a/shell/locales/en_GB.json
+++ b/shell/locales/en_GB.json
@@ -45,6 +45,7 @@
         "switcher_maximise": "Maximise",
         "switcher_restore": "Restore",
         "switcher_close": "Close",
+        "switcher_closeTab": "Close tab",
         "switcher_closeAll": "Close all",
         "switcher_empty": "No open apps",
 

--- a/shell/locales/en_GB.json
+++ b/shell/locales/en_GB.json
@@ -41,6 +41,7 @@
 
         "switcher_goHome": "Go home",
         "switcher_toggleList": "Toggle app switcher",
+        "switcher_newTab": "New tab",
         "switcher_minimise": "Minimise",
         "switcher_maximise": "Maximise",
         "switcher_restore": "Restore",

--- a/shell/locales/fr_FR.json
+++ b/shell/locales/fr_FR.json
@@ -41,6 +41,7 @@
 
         "switcher_goHome": "Retour à l'accueil",
         "switcher_toggleList": "Basculer le sélecteur d'application",
+        "switcher_newTab": "Nouvel onglet",
         "switcher_minimise": "Réduire",
         "switcher_maximise": "Agrandir",
         "switcher_restore": "Restaurer",

--- a/shell/locales/fr_FR.json
+++ b/shell/locales/fr_FR.json
@@ -45,6 +45,7 @@
         "switcher_maximise": "Agrandir",
         "switcher_restore": "Restaurer",
         "switcher_close": "Fermer",
+        "switcher_closeTab": "Fermer l'onglet",
         "switcher_closeAll": "Fermer tout",
         "switcher_empty": "Aucune application ouverte",
 

--- a/shell/sphere/sphere.css
+++ b/shell/sphere/sphere.css
@@ -31,17 +31,7 @@
     border: 0.2rem solid var(--primaryUIText);
 }
 
-.sphere_tabs {
-    width: 100%;
-    height: 100%;
-}
-
-.sphere_tab {
-    width: 100%;
-    height: 100%;
-}
-
-.sphere_tab webview {
+webview {
     width: 100%;
     height: 100%;
 }

--- a/shell/sphere/sphere.js
+++ b/shell/sphere/sphere.js
@@ -232,6 +232,7 @@ export function openBrowser() {
     return switcher.openWindow(browser.render(), {
         name: _("sphere"),
         icon: "gshell://sphere/icon.svg",
-        instantLaunch: true
+        instantLaunch: true,
+        showTabs: true
     });
 }

--- a/shell/sphere/sphere.js
+++ b/shell/sphere/sphere.js
@@ -20,7 +20,10 @@ export const FULL_CHROME_MIN_WIDTH = calc.getRemSize(30);
 export class Browser {
     constructor() {
         this.screenElement = null;
+        this.appElement = null;
         this.isFullChrome = false;
+        this.lastTitle = null;
+        this.lastIcon = null;
     }
 
     static normaliseUrl(url) {
@@ -87,6 +90,26 @@ export class Browser {
                 webview.focus();
     
                 thisScope.updateChrome();
+            });
+
+            webview.on("page-title-updated", function(event) {
+                thisScope.lastTitle = event.title;
+
+                if (thisScope.appElement == null) {
+                    return;
+                }
+
+                switcher.setAppCustomTab(thisScope.appElement, thisScope.lastTitle, thisScope.lastIcon);
+            });
+
+            webview.on("page-favicon-updated", function(event) {
+                thisScope.lastIcon = event.favicons[0];
+
+                if (thisScope.appElement == null) {
+                    return;
+                }
+
+                switcher.setAppCustomTab(thisScope.appElement, thisScope.lastTitle, thisScope.lastIcon);
             });
     
             thisScope.uiMain.add(webview);
@@ -233,12 +256,12 @@ export function openBrowser() {
             var browser = new Browser();
 
             browser.screenElement = screenElement;
-
-            switcher.addAppToWindow(screenElement, browser.render(), details);
+            browser.appElement = switcher.addAppToWindow(screenElement, browser.render(), details);
         }
     };
 
-    return switcher.openWindow(browser.render(), details, function(element) {
-        browser.screenElement = element;
+    return switcher.openWindow(browser.render(), details, function(screenElement, appElement) {
+        browser.screenElement = screenElement;
+        browser.appElement = appElement;
     });
 }

--- a/shell/sphere/sphere.js
+++ b/shell/sphere/sphere.js
@@ -176,20 +176,6 @@ export class Browser {
             $g.create("button")
                 .addClass("sphere_tabButton")
                 .setText("0")
-                .on("click", function() {
-                    if (thisScope.screenElement == null) {
-                        return;
-                    }
-
-                    var browser = new Browser();
-
-                    browser.screenElement = thisScope.screenElement;
-
-                    switcher.addAppToWindow(thisScope.screenElement, browser.render(), {
-                        name: _("sphere"),
-                        icon: "gshell://sphere/icon.svg"
-                    });
-                })
             ,
             $g.create("button")
                 .setAttribute("aria-label", _("sphere_menu"))
@@ -238,12 +224,21 @@ export function init() {
 export function openBrowser() {
     var browser = new Browser();
 
-    return switcher.openWindow(browser.render(), {
+    var details = {
         name: _("sphere"),
         icon: "gshell://sphere/icon.svg",
         instantLaunch: true,
-        showTabs: true
-    }, function(element) {
+        showTabs: true,
+        newTabHandler: function(screenElement) {
+            var browser = new Browser();
+
+            browser.screenElement = screenElement;
+
+            switcher.addAppToWindow(screenElement, browser.render(), details);
+        }
+    };
+
+    return switcher.openWindow(browser.render(), details, function(element) {
         browser.screenElement = element;
     });
 }

--- a/shell/userenv/home.js
+++ b/shell/userenv/home.js
@@ -115,8 +115,6 @@ export function load() {
                 );
             });
 
-            console.log(scrollers, $g.sel(".home_pagination").getAll());
-
             scrollers.forEach(function(scroller, i) {
                 scroller.applyPagination($g.sel($g.sel(".home_pagination").getAll()[i]));
             });

--- a/shell/userenv/switcher.css
+++ b/shell/userenv/switcher.css
@@ -343,7 +343,7 @@ html[aui-istouch="false"] .switcher_titleBar button:hover, .switcher_titleBar bu
     display: flex;
     flex-grow: 1;
     height: 100%;
-    margin-inline-end: 0.3rem;
+    margin-inline-end: 0.8rem;
     overflow: hidden;
 }
 
@@ -354,7 +354,7 @@ html[aui-istouch="false"] .switcher_titleBar button:hover, .switcher_titleBar bu
     height: 100%;
     margin-inline-end: 0.2rem;
     border-radius: 0.5rem;
-    transition: 0.5s background-color;
+    transition: 0.5s width, 0.5s background-color;
 }
 
 html[aui-istouch="false"] .switcher_tab:not(.switcher_titleBar.hideTabs *):hover, .switcher_tab:not(.switcher_titleBar.hideTabs *):active {
@@ -365,8 +365,12 @@ html[aui-istouch="false"] .switcher_tab:not(.switcher_titleBar.hideTabs *):hover
     width: 100%;
 }
 
-.switcher_tab.switcher_tab:not(.switcher_titleBar.hideTabs *).selected {
+.switcher_tab:not(.switcher_titleBar.hideTabs *).selected {
     background-color: var(--secondarySelected);
+}
+
+.switcher_tab.transitioning {
+    width: 0;
 }
 
 .switcher_tab button * {

--- a/shell/userenv/switcher.css
+++ b/shell/userenv/switcher.css
@@ -379,6 +379,10 @@ html[aui-istouch="false"] .switcher_tab:not(.switcher_titleBar.hideTabs *):hover
     vertical-align: middle;
 }
 
+.switcher_titleBar.hideTabs .switcher_tab {
+    width: 100%;
+}
+
 .switcher_tabActivateButton {
     flex-grow: 1;
     overflow: hidden;
@@ -411,6 +415,14 @@ html[aui-istouch="false"] .switcher_tabActivateButton:hover, .switcher_tabActiva
     width: 1.8rem;
     height: 1.8rem;
     border-radius: 0.5rem;
+}
+
+.switcher_tabCloseButton {
+    transform: scale(0.8);
+}
+
+.switcher_titleBar.hideTabs .switcher_tabCloseButton {
+    display: none;
 }
 
 .switcher_windowButtons {

--- a/shell/userenv/switcher.css
+++ b/shell/userenv/switcher.css
@@ -425,6 +425,10 @@ html[aui-istouch="false"] .switcher_tabActivateButton:hover, .switcher_tabActiva
     display: none;
 }
 
+.switcher_titleBar.hideTabs .switcher_tabNewButton {
+    display: none;
+}
+
 .switcher_windowButtons {
     height: 100%;
     flex-shrink: 0;

--- a/shell/userenv/switcher.css
+++ b/shell/userenv/switcher.css
@@ -350,10 +350,11 @@ html[aui-istouch="false"] .switcher_titleBar button:hover, .switcher_titleBar bu
 .switcher_tab {
     display: flex;
     width: 14.5rem;
-    min-width: 1.5rem;
+    min-width: 1.8rem;
     height: 100%;
     margin-inline-end: 0.2rem;
     border-radius: 0.5rem;
+    overflow: hidden;
     transition: 0.5s width, 0.5s background-color;
 }
 
@@ -371,6 +372,7 @@ html[aui-istouch="false"] .switcher_tab:not(.switcher_titleBar.hideTabs *):hover
 
 .switcher_tab.transitioning {
     width: 0;
+    min-width: 0;
 }
 
 .switcher_tab button * {

--- a/shell/userenv/switcher.css
+++ b/shell/userenv/switcher.css
@@ -326,8 +326,9 @@ body[device-type="desktop"] .switcher:not(.allowSelect) .switcher_screenButton {
 .switcher_titleBar button {
     height: 100%;
     margin: 0;
-    padding: 0.2rem;
+    padding: 0.19rem; /* Aligns better in terms of pixels */
     background-color: transparent;
+    color: inherit;
 }
 
 html[aui-istouch="false"] .switcher_titleBar button:hover, .switcher_titleBar button:active {
@@ -338,18 +339,77 @@ html[aui-istouch="false"] .switcher_titleBar button:hover, .switcher_titleBar bu
     height: 100%;
 }
 
+.switcher_tabs {
+    display: flex;
+    flex-grow: 1;
+    height: 100%;
+    margin-inline-end: 0.3rem;
+    overflow: hidden;
+}
+
+.switcher_tab {
+    display: flex;
+    width: 14.5rem;
+    min-width: 1.5rem;
+    height: 100%;
+    margin-inline-end: 0.2rem;
+    border-radius: 0.5rem;
+    transition: 0.5s background-color;
+}
+
+html[aui-istouch="false"] .switcher_tab:not(.switcher_titleBar.hideTabs *):hover, .switcher_tab:not(.switcher_titleBar.hideTabs *):active {
+    background-color: var(--secondaryPress);
+}
+
+.switcher_tabActivateButton .switcher_tab {
+    width: 100%;
+}
+
+.switcher_tab.switcher_tab:not(.switcher_titleBar.hideTabs *).selected {
+    background-color: var(--secondarySelected);
+}
+
+.switcher_tab button * {
+    vertical-align: middle;
+}
+
+.switcher_tabActivateButton {
+    flex-grow: 1;
+    overflow: hidden;
+    text-align: start;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    transition: 0.5s padding;
+}
+
+html[aui-istouch="false"] .switcher_tabActivateButton:hover, .switcher_tabActivateButton:active {
+    background-color: transparent!important;
+}
+
+.switcher_titleBar.hideTabs .switcher_tabActivateButton {
+    padding: 0;
+}
+
 .switcher_windowIcon {
-    width: 1.8rem;
-    height: 1.8rem;
+    width: 1.43rem;
+    height: 1.43rem;
     margin-inline-end: 0.5rem;
     background-color: white;
-    border-radius: 0.5rem;
+    border-radius: 0.4rem;
     object-fit: contain;
     pointer-events: none;
+    transition: 0.5s width, 0.5s height;
+}
+
+.switcher_titleBar.hideTabs .switcher_windowIcon {
+    width: 1.8rem;
+    height: 1.8rem;
+    border-radius: 0.5rem;
 }
 
 .switcher_windowButtons {
     height: 100%;
+    flex-shrink: 0;
 }
 
 .switcher_screen.maximised .switcher_maximiseButton {

--- a/shell/userenv/switcher.css
+++ b/shell/userenv/switcher.css
@@ -390,7 +390,7 @@ html[aui-istouch="false"] .switcher_tabActivateButton:hover, .switcher_tabActiva
     padding: 0;
 }
 
-.switcher_windowIcon {
+.switcher_tabIcon {
     width: 1.43rem;
     height: 1.43rem;
     margin-inline-end: 0.5rem;
@@ -401,7 +401,7 @@ html[aui-istouch="false"] .switcher_tabActivateButton:hover, .switcher_tabActiva
     transition: 0.5s width, 0.5s height;
 }
 
-.switcher_titleBar.hideTabs .switcher_windowIcon {
+.switcher_titleBar.hideTabs .switcher_tabIcon {
     width: 1.8rem;
     height: 1.8rem;
     border-radius: 0.5rem;
@@ -476,6 +476,10 @@ body[device-type="desktop"] .switcher:not(.allowSelect) .switcher_screen.maximis
     height: 100%;
     border-radius: calc(0.8rem / 0.7);
     overflow: hidden;
+}
+
+.switcher_app.hidden {
+    display: none;
 }
 
 .switcher_app main {

--- a/shell/userenv/switcher.js
+++ b/shell/userenv/switcher.js
@@ -929,8 +929,6 @@ export function closeApp(element) {
 export function setAppCustomTab(element, title, icon) {
     element.get().usingCustomTab = true;
 
-    console.log(icon, element.get().tab.get());
-
     element.get().tab.find(".switcher_tabTitle").setText(title || "");
 
     if (icon) {

--- a/shell/userenv/switcher.js
+++ b/shell/userenv/switcher.js
@@ -302,7 +302,7 @@ export function openWindow(windowContents, appDetails = null) {
             screenElement.setStyle("cursor", cursor);
         })
         .on("pointerdown", function(event) {
-            if ($g.sel(event.target).is(".switcher_screen, .switcher_titleBar")) {
+            if ($g.sel(event.target).is(".switcher_screen, .switcher_titleBar, .switcher_tabs, .switcher_titleBar.hideTabs .switcher_tabs *")) {
                 $g.sel("#switcherView .switcher").addClass("manipulating");
 
                 initialGeometry = getWindowGeometry(screenElement);
@@ -316,6 +316,7 @@ export function openWindow(windowContents, appDetails = null) {
         .add(
             $g.create("div")
                 .addClass("switcher_titleBar")
+                .addClass("hideTabs")
                 .on("pointerdown", function(event) {
                     if (lastTitleBarPress != null && Date.now() - lastTitleBarPress <= a11y.options.touch_doublePressDelay) {
                         shouldCancelUnsnap = true;
@@ -330,15 +331,28 @@ export function openWindow(windowContents, appDetails = null) {
                     lastTitleBarPress = Date.now();
                 })
                 .add(
-                    $g.create("img")
-                        .addClass("switcher_windowIcon")
-                        .setAttribute("aria-hidden", true)
-                        .on("error", function() {
-                            screenElement.find(".switcher_windowIcon").setAttribute("src", "gshell://media/appdefault.svg")
-                        })
-                    ,
-                    $g.create("span")
-                        .addClass("switcher_windowTitle")
+                    $g.create("div")
+                        .addClass("switcher_tabs")
+                        .add(
+                            $g.create("div")
+                                .addClass("switcher_tab")
+                                .addClass("selected")
+                                .add(
+                                    $g.create("button")
+                                        .addClass("switcher_tabActivateButton")
+                                        .add(
+                                            $g.create("img")
+                                                .addClass("switcher_windowIcon")
+                                                .setAttribute("aria-hidden", true)
+                                                .on("error", function() {
+                                                    screenElement.find(".switcher_windowIcon").setAttribute("src", "gshell://media/appdefault.svg")
+                                                })
+                                            ,
+                                            $g.create("span")
+                                                .addClass("switcher_windowTitle")
+                                        )
+                                )
+                        )
                     ,
                     $g.create("div")
                         .addClass("switcher_windowButtons")

--- a/shell/userenv/switcher.js
+++ b/shell/userenv/switcher.js
@@ -490,7 +490,7 @@ export function openWindow(windowContents, appDetails = null, elementCallback = 
                 .addClass("desktop_appListButton_icon")
                 .setAttribute("aria-hidden", true)
                 .on("error", function() {
-                    screenElement.get().appListButton.find(".desktop_appListButton_icon").setAttribute("src", "gshell://media/appdefault.svg")
+                    screenElement.get().appListButton.find(".desktop_appListButton_icon").setAttribute("src", "gshell://media/appdefault.svg");
                 })
         )
         .on("click", function() {
@@ -628,7 +628,7 @@ export function openWindow(windowContents, appDetails = null, elementCallback = 
         screenElement.find(".switcher_titleBar").removeClass("hideTabs");
     }
 
-    addAppToWindow(screenElement, windowContents, appDetails);
+    var app = addAppToWindow(screenElement, windowContents, appDetails);
 
     function finishLaunch() {
         screenElement.removeClass("launching");
@@ -686,7 +686,7 @@ export function openWindow(windowContents, appDetails = null, elementCallback = 
 
     $g.sel(".desktop_homeMenu").menuClose();
 
-    elementCallback(screenElement);
+    elementCallback(screenElement, app);
 
     return $g.sel("#switcherView").screenFade();
 }
@@ -711,7 +711,7 @@ export function addAppToWindow(element, windowContents, appDetails = null) {
                         .addClass("switcher_tabIcon")
                         .setAttribute("aria-hidden", true)
                         .on("error", function() {
-                            element.find(".switcher_tabIcon").setAttribute("src", "gshell://media/appdefault.svg")
+                            element.find(".switcher_tabIcon").setAttribute("src", "gshell://media/appdefault.svg");
                         })
                     ,
                     $g.create("span")
@@ -737,11 +737,16 @@ export function addAppToWindow(element, windowContents, appDetails = null) {
     app.get().tab = tab;
     tab.get().app = app;
 
+    app.get().usingCustomTab = false;
     app.get().lastTitle = null;
     app.get().lastIcon = null;
 
     if (appDetails == null) {
         element.find("webview").on("page-title-updated", function(event) {
+            if (app.get().usingCustomTab) {
+                return;
+            }
+
             app.get().lastTitle = event.title;
 
             if (tab.hasClass("selected")) {
@@ -755,6 +760,10 @@ export function addAppToWindow(element, windowContents, appDetails = null) {
         });
 
         element.find("webview").on("page-favicon-updated", function(event) {
+            if (app.get().usingCustomTab) {
+                return;
+            }
+
             app.get().lastIcon = event.favicons[0];
 
             if (tab.hasClass("selected")) {
@@ -786,6 +795,8 @@ export function addAppToWindow(element, windowContents, appDetails = null) {
     setTimeout(function() {
         tab.removeClass("transitioning");
     });
+
+    return app;
 }
 
 export function minimiseWindow(element) {
@@ -913,6 +924,18 @@ export function closeApp(element) {
     setTimeout(function() {
         element.get().tab.remove();
     }, aui_a11y.prefersReducedMotion() ? 0 : 500);
+}
+
+export function setAppCustomTab(element, title, icon) {
+    element.get().usingCustomTab = true;
+
+    console.log(icon, element.get().tab.get());
+
+    element.get().tab.find(".switcher_tabTitle").setText(title || "");
+
+    if (icon) {
+        element.get().tab.find(".switcher_tabIcon").setAttribute("src", icon);
+    }
 }
 
 export function showList() {

--- a/shell/userenv/switcher.js
+++ b/shell/userenv/switcher.js
@@ -252,7 +252,7 @@ export function setWindowGeometry(element, geometry = getWindowGeometry(element)
     }
 }
 
-export function openWindow(windowContents, appDetails = null) {
+export function openWindow(windowContents, appDetails = null, elementCallback = function() {}) {
     var initialGeometry = null;
     var pointerDown = false;
     var moveResizeMode = new WindowMoveResizeMode();
@@ -318,17 +318,19 @@ export function openWindow(windowContents, appDetails = null) {
                 .addClass("switcher_titleBar")
                 .addClass("hideTabs")
                 .on("pointerdown", function(event) {
-                    if (lastTitleBarPress != null && Date.now() - lastTitleBarPress <= a11y.options.touch_doublePressDelay) {
-                        shouldCancelUnsnap = true;
-
-                        if (!screenElement.hasClass("maximised")) {
-                            maximiseWindow(screenElement);
-                        } else {
-                            restoreWindow(screenElement);
+                    if (!$g.sel(event.target).is(".switcher_titleBar:not(.hideTabs) .switcher_tabs *, .switcher_windowButtons *")) {
+                        if (lastTitleBarPress != null && Date.now() - lastTitleBarPress <= a11y.options.touch_doublePressDelay) {
+                            shouldCancelUnsnap = true;
+    
+                            if (!screenElement.hasClass("maximised")) {
+                                maximiseWindow(screenElement);
+                            } else {
+                                restoreWindow(screenElement);
+                            }
                         }
+    
+                        lastTitleBarPress = Date.now();
                     }
-
-                    lastTitleBarPress = Date.now();
                 })
                 .add(
                     $g.create("div").addClass("switcher_tabs"),
@@ -655,6 +657,8 @@ export function openWindow(windowContents, appDetails = null) {
 
     $g.sel(".desktop_homeMenu").menuClose();
 
+    elementCallback(screenElement);
+
     return $g.sel("#switcherView").screenFade();
 }
 
@@ -669,6 +673,7 @@ export function addAppToWindow(element, windowContents, appDetails = null) {
     var tab = $g.create("div")
         .addClass("switcher_tab")
         .addClass("selected")
+        .addClass("transitioning")
         .add(
             $g.create("button")
                 .addClass("switcher_tabActivateButton")
@@ -743,6 +748,10 @@ export function addAppToWindow(element, windowContents, appDetails = null) {
     });
 
     element.find(".switcher_tabs").add(tab);
+
+    setTimeout(function() {
+        tab.removeClass("transitioning");
+    });
 }
 
 export function minimiseWindow(element) {

--- a/src/main.js
+++ b/src/main.js
@@ -41,7 +41,6 @@ electron.protocol.registerSchemesAsPrivileged([
 ]);
 
 electron.app.on("ready", function() {
-    console.log(path.join(rootDirectory, "shell", "lib", "adaptui", "src", "adaptui.js"));
     if (!fs.existsSync(path.join(rootDirectory, "shell", "lib", "adaptui", "src", "adaptui.js"))) {
         console.error("Missing required dependency: Adapt UI");
         console.error("Please ensure that you clone the required submodules to install the dependencies.");


### PR DESCRIPTION
This PR adds the ability to add multiple tabs to windows. Its primary use case is to allow users to open multiple webpages as tabs in Sphere, but the functionality also works for other purposes, too, through an API that we will make available to apps so that they can choose to show a tabbed interface and open up tabs in their window themselves.

We will also allow windows to contain multiple tabs from different apps, so that apps in similar categories (such as, for example, email and calendar apps) can be contained in the same window.