### PR TITLE
Add support for Widevine DRM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "mkdirp": "^0.5.6"
             },
             "devDependencies": {
-                "electron": "^22.0.0",
+                "electron": "github:castlabs/electron-releases#v22.0.0+wvcus",
                 "electron-builder": "^22.10.3"
             }
         },
@@ -55,6 +55,131 @@
                 "global-agent": "^3.0.0"
             }
         },
+        "node_modules/@electron/universal": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.5.tgz",
+            "integrity": "sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==",
+            "dev": true,
+            "dependencies": {
+                "@malept/cross-spawn-promise": "^1.1.0",
+                "asar": "^3.0.3",
+                "debug": "^4.3.1",
+                "dir-compare": "^2.4.0",
+                "fs-extra": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/@electron/universal/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@electron/universal/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@electron/universal/node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@malept/cross-spawn-promise": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+            "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/malept"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+                }
+            ],
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@malept/flatpak-bundler": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+            "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.1.1",
+                "fs-extra": "^9.0.0",
+                "lodash": "^4.17.15",
+                "tmp-promise": "^3.0.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
         "node_modules/@sindresorhus/is": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -77,6 +202,15 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/@types/cacheable-request": {
@@ -109,6 +243,17 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/glob": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/http-cache-semantics": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -124,6 +269,13 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/minimatch": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+            "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+            "dev": true,
+            "optional": true
+        },
         "node_modules/@types/ms": {
             "version": "0.7.31",
             "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
@@ -131,9 +283,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.11.45",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz",
-            "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ==",
+            "version": "16.18.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
+            "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
             "dev": true
         },
         "node_modules/@types/plist": {
@@ -164,9 +316,9 @@
             "optional": true
         },
         "node_modules/@types/yargs": {
-            "version": "15.0.14",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-            "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+            "version": "17.0.19",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
+            "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
             "dev": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
@@ -189,10 +341,22 @@
             }
         },
         "node_modules/7zip-bin": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.0.3.tgz",
-            "integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz",
+            "integrity": "sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==",
             "dev": true
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
         },
         "node_modules/ajv": {
             "version": "6.12.6",
@@ -253,57 +417,59 @@
             }
         },
         "node_modules/app-builder-bin": {
-            "version": "3.5.10",
-            "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.5.10.tgz",
-            "integrity": "sha512-Jd+GW68lR0NeetgZDo47PdWBEPdnD+p0jEa7XaxjRC8u6Oo/wgJsfKUkORRgr2NpkD19IFKN50P6JYy04XHFLQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.7.1.tgz",
+            "integrity": "sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw==",
             "dev": true
         },
         "node_modules/app-builder-lib": {
-            "version": "22.10.3",
-            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.10.3.tgz",
-            "integrity": "sha512-PBHTTGxV1uLVHWKQfw92plrfMo/utH0FVe8v2dFmT/CYKw9u7XuOC0xE8YslUxXmaiG6TuOJaQrII4fXN5VBpQ==",
+            "version": "22.14.13",
+            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.14.13.tgz",
+            "integrity": "sha512-SufmrtxU+D0Tn948fjEwAOlCN9757UXLkzzTWXMwZKR/5hisvgqeeBepWfphMIE6OkDGz0fbzEhL1P2Pty4XMg==",
             "dev": true,
             "dependencies": {
                 "@develar/schema-utils": "~2.6.5",
-                "7zip-bin": "~5.0.3",
+                "@electron/universal": "1.0.5",
+                "@malept/flatpak-bundler": "^0.4.0",
+                "7zip-bin": "~5.1.1",
                 "async-exit-hook": "^2.0.1",
                 "bluebird-lst": "^1.0.9",
-                "builder-util": "22.10.3",
-                "builder-util-runtime": "8.7.3",
+                "builder-util": "22.14.13",
+                "builder-util-runtime": "8.9.2",
                 "chromium-pickle-js": "^0.2.0",
                 "debug": "^4.3.2",
-                "ejs": "^3.1.5",
-                "electron-publish": "22.10.3",
-                "fs-extra": "^9.0.1",
-                "hosted-git-info": "^3.0.7",
-                "is-ci": "^2.0.0",
-                "isbinaryfile": "^4.0.6",
-                "js-yaml": "^3.14.1",
-                "lazy-val": "^1.0.4",
+                "ejs": "^3.1.6",
+                "electron-osx-sign": "^0.5.0",
+                "electron-publish": "22.14.13",
+                "form-data": "^4.0.0",
+                "fs-extra": "^10.0.0",
+                "hosted-git-info": "^4.0.2",
+                "is-ci": "^3.0.0",
+                "isbinaryfile": "^4.0.8",
+                "js-yaml": "^4.1.0",
+                "lazy-val": "^1.0.5",
                 "minimatch": "^3.0.4",
-                "normalize-package-data": "^3.0.0",
-                "read-config-file": "6.0.0",
+                "read-config-file": "6.2.0",
                 "sanitize-filename": "^1.6.3",
-                "semver": "^7.3.4",
-                "temp-file": "^3.3.7"
+                "semver": "^7.3.5",
+                "temp-file": "^3.4.0"
             },
             "engines": {
-                "node": ">=8.12.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/app-builder-lib/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "dependencies": {
-                "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/app-builder-lib/node_modules/jsonfile": {
@@ -343,12 +509,31 @@
             }
         },
         "node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "node_modules/asar": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
+            "integrity": "sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==",
+            "deprecated": "Please use @electron/asar moving forward.  There is no API change, just a package name change",
             "dev": true,
             "dependencies": {
-                "sprintf-js": "~1.0.2"
+                "chromium-pickle-js": "^0.2.0",
+                "commander": "^5.0.0",
+                "glob": "^7.1.6",
+                "minimatch": "^3.0.4"
+            },
+            "bin": {
+                "asar": "bin/asar.js"
+            },
+            "engines": {
+                "node": ">=10.12.0"
+            },
+            "optionalDependencies": {
+                "@types/glob": "^7.1.1"
             }
         },
         "node_modules/assert-plus": {
@@ -386,6 +571,12 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true
+        },
         "node_modules/at-least-node": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -419,13 +610,12 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "optional": true
+            ]
         },
         "node_modules/bcryptjs": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-            "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+            "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
         },
         "node_modules/bluebird": {
             "version": "3.7.2",
@@ -518,6 +708,22 @@
                 "ieee754": "^1.1.13"
             }
         },
+        "node_modules/buffer-alloc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+            "dev": true,
+            "dependencies": {
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
+            }
+        },
+        "node_modules/buffer-alloc-unsafe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+            "dev": true
+        },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -527,6 +733,21 @@
                 "node": "*"
             }
         },
+        "node_modules/buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/buffer-fill": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+            "dev": true
+        },
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -534,53 +755,55 @@
             "dev": true
         },
         "node_modules/builder-util": {
-            "version": "22.10.3",
-            "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.10.3.tgz",
-            "integrity": "sha512-I9mh78wZaggIF4QkBzMPKhfgGDameyx9TN6Zikl8SKQHiKQNCUzMPUcRXCyCot6iTT8B8blwOM3GhhuU06yv1g==",
+            "version": "22.14.13",
+            "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.14.13.tgz",
+            "integrity": "sha512-oePC/qrrUuerhmH5iaCJzPRAKlSBylrhzuAJmRQClTyWnZUv6jbaHh+VoHMbEiE661wrj2S2aV7/bQh12cj1OA==",
             "dev": true,
             "dependencies": {
-                "@types/debug": "^4.1.5",
-                "@types/fs-extra": "^9.0.5",
-                "7zip-bin": "~5.0.3",
-                "app-builder-bin": "3.5.10",
+                "@types/debug": "^4.1.6",
+                "@types/fs-extra": "^9.0.11",
+                "7zip-bin": "~5.1.1",
+                "app-builder-bin": "3.7.1",
                 "bluebird-lst": "^1.0.9",
-                "builder-util-runtime": "8.7.3",
-                "chalk": "^4.1.0",
+                "builder-util-runtime": "8.9.2",
+                "chalk": "^4.1.1",
+                "cross-spawn": "^7.0.3",
                 "debug": "^4.3.2",
-                "fs-extra": "^9.0.1",
-                "is-ci": "^2.0.0",
-                "js-yaml": "^3.14.1",
+                "fs-extra": "^10.0.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "is-ci": "^3.0.0",
+                "js-yaml": "^4.1.0",
                 "source-map-support": "^0.5.19",
                 "stat-mode": "^1.0.0",
-                "temp-file": "^3.3.7"
+                "temp-file": "^3.4.0"
             }
         },
         "node_modules/builder-util-runtime": {
-            "version": "8.7.3",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz",
-            "integrity": "sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==",
+            "version": "8.9.2",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.2.tgz",
+            "integrity": "sha512-rhuKm5vh7E0aAmT6i8aoSfEjxzdYEFX7zDApK+eNgOhjofnWb74d9SRJv0H/8nsgOkos0TZ4zxW0P8J4N7xQ2A==",
             "dev": true,
             "dependencies": {
                 "debug": "^4.3.2",
                 "sax": "^1.2.4"
             },
             "engines": {
-                "node": ">=8.2.5"
+                "node": ">=12.0.0"
             }
         },
         "node_modules/builder-util/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "dependencies": {
-                "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/builder-util/node_modules/jsonfile": {
@@ -666,10 +889,19 @@
             "dev": true
         },
         "node_modules/ci-info": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-            "dev": true
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+            "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/cli-boxes": {
             "version": "2.2.1",
@@ -701,14 +933,17 @@
             }
         },
         "node_modules/cliui": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dev": true,
             "dependencies": {
                 "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
+                "strip-ansi": "^6.0.1",
                 "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/clone-response": {
@@ -740,6 +975,45 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
+        },
+        "node_modules/colors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/commander": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/compare-version": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+            "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -779,6 +1053,20 @@
             "optional": true,
             "dependencies": {
                 "buffer": "^5.1.0"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/crypto-random-string": {
@@ -869,6 +1157,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/detect-node": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -876,36 +1173,74 @@
             "dev": true,
             "optional": true
         },
-        "node_modules/dmg-builder": {
-            "version": "22.10.3",
-            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.10.3.tgz",
-            "integrity": "sha512-OB0etdtZJrvx85ah1aoTv5zJ9CXlsepLs9VT6ax6FXxH9aGxJU38AuB8065OPTrj+btMuHQDd0kBVlcs4/BwpA==",
+        "node_modules/dir-compare": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-2.4.0.tgz",
+            "integrity": "sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==",
             "dev": true,
             "dependencies": {
-                "app-builder-lib": "22.10.3",
-                "builder-util": "22.10.3",
-                "fs-extra": "^9.0.1",
+                "buffer-equal": "1.0.0",
+                "colors": "1.0.3",
+                "commander": "2.9.0",
+                "minimatch": "3.0.4"
+            },
+            "bin": {
+                "dircompare": "src/cli/dircompare.js"
+            }
+        },
+        "node_modules/dir-compare/node_modules/commander": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+            "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
+            "dev": true,
+            "dependencies": {
+                "graceful-readlink": ">= 1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6.x"
+            }
+        },
+        "node_modules/dir-compare/node_modules/minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/dmg-builder": {
+            "version": "22.14.13",
+            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.14.13.tgz",
+            "integrity": "sha512-xNOugB6AbIRETeU2uID15sUfjdZZcKdxK8xkFnwIggsM00PJ12JxpLNPTjcRoUnfwj3WrPjilrO64vRMwNItQg==",
+            "dev": true,
+            "dependencies": {
+                "app-builder-lib": "22.14.13",
+                "builder-util": "22.14.13",
+                "builder-util-runtime": "8.9.2",
+                "fs-extra": "^10.0.0",
                 "iconv-lite": "^0.6.2",
-                "js-yaml": "^3.14.1",
-                "sanitize-filename": "^1.6.3"
+                "js-yaml": "^4.1.0"
             },
             "optionalDependencies": {
-                "dmg-license": "^1.0.8"
+                "dmg-license": "^1.0.9"
             }
         },
         "node_modules/dmg-builder/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "dependencies": {
-                "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/dmg-builder/node_modules/jsonfile": {
@@ -968,9 +1303,9 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-            "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+            "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
             "dev": true,
             "engines": {
                 "node": ">=10"
@@ -1004,11 +1339,11 @@
             }
         },
         "node_modules/electron": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-22.0.0.tgz",
-            "integrity": "sha512-cgRc4wjyM+81A0E8UGv1HNJjL1HBI5cWNh/DUIjzYvoUuiEM0SS0hAH/zaFQ18xOz2ced6Yih8SybpOiOYJhdg==",
+            "version": "22.0.0+wvcus",
+            "resolved": "git+ssh://git@github.com/castlabs/electron-releases.git#ee6e1f03b8e5097232a12d4e2cb616b8b5cf54ef",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "dependencies": {
                 "@electron/get": "^2.0.0",
                 "@types/node": "^16.11.26",
@@ -1022,47 +1357,44 @@
             }
         },
         "node_modules/electron-builder": {
-            "version": "22.10.3",
-            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.10.3.tgz",
-            "integrity": "sha512-TNKmeYWrnATD/BBkpmNF03+wAA3+K8DZ6d/F1ipAKCbqeILp4agnr5nrngz+xpl7Y83lhelC1moU4utHNWYhzw==",
+            "version": "22.14.13",
+            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.14.13.tgz",
+            "integrity": "sha512-3fgLxqF2TXVKiUPeg74O4V3l0l3j7ERLazo8sUbRkApw0+4iVAf2BJkHsHMaXiigsgCoEzK/F4/rB5rne/VAnw==",
             "dev": true,
             "dependencies": {
-                "@types/yargs": "^15.0.11",
-                "app-builder-lib": "22.10.3",
-                "bluebird-lst": "^1.0.9",
-                "builder-util": "22.10.3",
-                "builder-util-runtime": "8.7.3",
-                "chalk": "^4.1.0",
-                "dmg-builder": "22.10.3",
-                "fs-extra": "^9.0.1",
-                "is-ci": "^2.0.0",
-                "lazy-val": "^1.0.4",
-                "read-config-file": "6.0.0",
-                "sanitize-filename": "^1.6.3",
-                "update-notifier": "^5.0.1",
-                "yargs": "^16.2.0"
+                "@types/yargs": "^17.0.1",
+                "app-builder-lib": "22.14.13",
+                "builder-util": "22.14.13",
+                "builder-util-runtime": "8.9.2",
+                "chalk": "^4.1.1",
+                "dmg-builder": "22.14.13",
+                "fs-extra": "^10.0.0",
+                "is-ci": "^3.0.0",
+                "lazy-val": "^1.0.5",
+                "read-config-file": "6.2.0",
+                "update-notifier": "^5.1.0",
+                "yargs": "^17.0.1"
             },
             "bin": {
-                "electron-builder": "out/cli/cli.js",
-                "install-app-deps": "out/cli/install-app-deps.js"
+                "electron-builder": "cli.js",
+                "install-app-deps": "install-app-deps.js"
             },
             "engines": {
-                "node": ">=8.12.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/electron-builder/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "dependencies": {
-                "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/electron-builder/node_modules/jsonfile": {
@@ -1086,35 +1418,82 @@
                 "node": ">= 10.0.0"
             }
         },
-        "node_modules/electron-publish": {
-            "version": "22.10.3",
-            "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.10.3.tgz",
-            "integrity": "sha512-NGcgDp0xT92NPB5lGckroz2n5h8Ud53SShmwZoVtCp1W+VOSWn5CVPnXDquzf7pMcZRfo8qoMZrlvUeOlY4oIg==",
+        "node_modules/electron-osx-sign": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
+            "integrity": "sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==",
+            "deprecated": "Please use @electron/osx-sign moving forward. Be aware the API is slightly different",
             "dev": true,
             "dependencies": {
-                "@types/fs-extra": "^9.0.5",
-                "bluebird-lst": "^1.0.9",
-                "builder-util": "22.10.3",
-                "builder-util-runtime": "8.7.3",
-                "chalk": "^4.1.0",
-                "fs-extra": "^9.0.1",
-                "lazy-val": "^1.0.4",
-                "mime": "^2.4.6"
+                "bluebird": "^3.5.0",
+                "compare-version": "^0.1.2",
+                "debug": "^2.6.8",
+                "isbinaryfile": "^3.0.2",
+                "minimist": "^1.2.0",
+                "plist": "^3.0.1"
+            },
+            "bin": {
+                "electron-osx-flat": "bin/electron-osx-flat.js",
+                "electron-osx-sign": "bin/electron-osx-sign.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/electron-osx-sign/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/electron-osx-sign/node_modules/isbinaryfile": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+            "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+            "dev": true,
+            "dependencies": {
+                "buffer-alloc": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
+        "node_modules/electron-osx-sign/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true
+        },
+        "node_modules/electron-publish": {
+            "version": "22.14.13",
+            "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.14.13.tgz",
+            "integrity": "sha512-0oP3QiNj3e8ewOaEpEJV/o6Zrmy2VarVvZ/bH7kyO/S/aJf9x8vQsKVWpsdmSiZ5DJEHgarFIXrnO0ZQf0P9iQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/fs-extra": "^9.0.11",
+                "builder-util": "22.14.13",
+                "builder-util-runtime": "8.9.2",
+                "chalk": "^4.1.1",
+                "fs-extra": "^10.0.0",
+                "lazy-val": "^1.0.5",
+                "mime": "^2.5.2"
             }
         },
         "node_modules/electron-publish/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "dependencies": {
-                "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/electron-publish/node_modules/jsonfile": {
@@ -1200,19 +1579,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/extract-zip": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -1283,15 +1649,29 @@
             }
         },
         "node_modules/filelist/node_modules/minimatch": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-            "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.5.tgz",
+            "integrity": "sha512-CI8wwdrll4ehjPAqs8TL8lBPyNnpZlQI02Wn8C1weNz/QbUbjh3OMxgMKSnvqfKFdLlks3EzHB9tO0BqGc3phQ==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dev": true,
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/fs-extra": {
@@ -1308,11 +1688,18 @@
                 "node": ">=6 <7 || >=8"
             }
         },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
@@ -1351,6 +1738,26 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/global-agent": {
@@ -1449,11 +1856,18 @@
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
         },
+        "node_modules/graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
+            "dev": true
+        },
         "node_modules/has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
+            "optional": true,
             "dependencies": {
                 "function-bind": "^1.1.1"
             },
@@ -1506,9 +1920,9 @@
             }
         },
         "node_modules/hosted-git-info": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
-            "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -1523,6 +1937,20 @@
             "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
             "dev": true
         },
+        "node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/http2-wrapper": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
@@ -1534,6 +1962,19 @@
             },
             "engines": {
                 "node": ">=10.19.0"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/iconv-corefoundation": {
@@ -1604,6 +2045,22 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
         "node_modules/ini": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
@@ -1614,27 +2071,15 @@
             }
         },
         "node_modules/is-ci": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+            "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
             "dev": true,
             "dependencies": {
-                "ci-info": "^2.0.0"
+                "ci-info": "^3.2.0"
             },
             "bin": {
                 "is-ci": "bin.js"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-            "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-            "dev": true,
-            "dependencies": {
-                "has": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-fullwidth-code-point": {
@@ -1716,6 +2161,12 @@
                 "url": "https://github.com/sponsors/gjtorikian/"
             }
         },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
+        },
         "node_modules/jake": {
             "version": "10.8.5",
             "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
@@ -1735,13 +2186,12 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
@@ -1767,9 +2217,9 @@
             "optional": true
         },
         "node_modules/json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
@@ -1812,6 +2262,12 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
             "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+            "dev": true
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "node_modules/lowercase-keys": {
@@ -1875,6 +2331,27 @@
                 "node": ">=4.0.0"
             }
         },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/mimic-response": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -1897,9 +2374,12 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/mkdirp": {
             "version": "0.5.6",
@@ -1924,48 +2404,6 @@
             "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
             "dev": true,
             "optional": true
-        },
-        "node_modules/normalize-package-data": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-            "dev": true,
-            "dependencies": {
-                "hosted-git-info": "^4.0.1",
-                "is-core-module": "^2.5.0",
-                "semver": "^7.3.4",
-                "validate-npm-package-license": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/normalize-package-data/node_modules/hosted-git-info": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/normalize-package-data/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/normalize-url": {
             "version": "6.1.0",
@@ -2173,6 +2611,24 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -2184,7 +2640,6 @@
             "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
             "integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
             "dev": true,
-            "optional": true,
             "dependencies": {
                 "base64-js": "^1.5.1",
                 "xmlbuilder": "^15.1.1"
@@ -2222,9 +2677,9 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
+            "integrity": "sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -2276,19 +2731,19 @@
             "dev": true
         },
         "node_modules/read-config-file": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.0.0.tgz",
-            "integrity": "sha512-PHjROSdpceKUmqS06wqwP92VrM46PZSTubmNIMJ5DrMwg1OgenSTSEHIkCa6TiOJ+y/J0xnG1fFwG3M+Oi1aNA==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.2.0.tgz",
+            "integrity": "sha512-gx7Pgr5I56JtYz+WuqEbQHj/xWo+5Vwua2jhb1VwM4Wid5PqYmZ4i00ZB0YEGIfkVBsCv9UrjgyqCiQfS/Oosg==",
             "dev": true,
             "dependencies": {
-                "dotenv": "^8.2.0",
+                "dotenv": "^9.0.2",
                 "dotenv-expand": "^5.1.0",
-                "js-yaml": "^3.13.1",
-                "json5": "^2.1.2",
+                "js-yaml": "^4.1.0",
+                "json5": "^2.2.0",
                 "lazy-val": "^1.0.4"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=12.0.0"
             }
         },
         "node_modules/registry-auth-token": {
@@ -2342,6 +2797,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/roarr": {
             "version": "2.15.4",
             "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -2359,13 +2829,6 @@
             "engines": {
                 "node": ">=8.0"
             }
-        },
-        "node_modules/roarr/node_modules/sprintf-js": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-            "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-            "dev": true,
-            "optional": true
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -2432,6 +2895,27 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -2483,43 +2967,12 @@
                 "source-map": "^0.6.0"
             }
         },
-        "node_modules/spdx-correct": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-            "dev": true,
-            "dependencies": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-exceptions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-            "dev": true
-        },
-        "node_modules/spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-license-ids": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-            "dev": true
-        },
         "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+            "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+            "dev": true,
+            "optional": true
         },
         "node_modules/stat-mode": {
             "version": "1.0.0",
@@ -2634,6 +3087,27 @@
                 "node": ">= 10.0.0"
             }
         },
+        "node_modules/tmp": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+            "dev": true,
+            "dependencies": {
+                "rimraf": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8.17.0"
+            }
+        },
+        "node_modules/tmp-promise": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+            "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+            "dev": true,
+            "dependencies": {
+                "tmp": "^0.2.0"
+            }
+        },
         "node_modules/to-readable-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
@@ -2723,6 +3197,24 @@
                 "url": "https://github.com/yeoman/update-notifier?sponsor=1"
             }
         },
+        "node_modules/update-notifier/node_modules/ci-info": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "dev": true
+        },
+        "node_modules/update-notifier/node_modules/is-ci": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "dev": true,
+            "dependencies": {
+                "ci-info": "^2.0.0"
+            },
+            "bin": {
+                "is-ci": "bin.js"
+            }
+        },
         "node_modules/update-notifier/node_modules/semver": {
             "version": "7.3.8",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -2765,16 +3257,6 @@
             "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
             "dev": true
         },
-        "node_modules/validate-npm-package-license": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
-            "dependencies": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-            }
-        },
         "node_modules/verror": {
             "version": "1.10.1",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
@@ -2788,6 +3270,21 @@
             },
             "engines": {
                 "node": ">=0.6.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/widest-line": {
@@ -2851,7 +3348,6 @@
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
             "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
             "dev": true,
-            "optional": true,
             "engines": {
                 "node": ">=8.0"
             }
@@ -2872,30 +3368,30 @@
             "dev": true
         },
         "node_modules/yargs": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "version": "17.6.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+            "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
             "dev": true,
             "dependencies": {
-                "cliui": "^7.0.2",
+                "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
-                "string-width": "^4.2.0",
+                "string-width": "^4.2.3",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^20.2.2"
+                "yargs-parser": "^21.1.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/yargs-parser": {
-            "version": "20.2.9",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true,
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/yauzl": {
@@ -2936,6 +3432,100 @@
                 "sumchecker": "^3.0.1"
             }
         },
+        "@electron/universal": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.5.tgz",
+            "integrity": "sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==",
+            "dev": true,
+            "requires": {
+                "@malept/cross-spawn-promise": "^1.1.0",
+                "asar": "^3.0.3",
+                "debug": "^4.3.1",
+                "dir-compare": "^2.4.0",
+                "fs-extra": "^9.0.1"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@malept/cross-spawn-promise": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+            "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^7.0.1"
+            }
+        },
+        "@malept/flatpak-bundler": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+            "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "fs-extra": "^9.0.0",
+                "lodash": "^4.17.15",
+                "tmp-promise": "^3.0.2"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
+            }
+        },
         "@sindresorhus/is": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -2950,6 +3540,12 @@
             "requires": {
                 "defer-to-connect": "^2.0.0"
             }
+        },
+        "@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "dev": true
         },
         "@types/cacheable-request": {
             "version": "6.0.3",
@@ -2981,6 +3577,17 @@
                 "@types/node": "*"
             }
         },
+        "@types/glob": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
         "@types/http-cache-semantics": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -2996,6 +3603,13 @@
                 "@types/node": "*"
             }
         },
+        "@types/minimatch": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+            "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+            "dev": true,
+            "optional": true
+        },
         "@types/ms": {
             "version": "0.7.31",
             "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
@@ -3003,9 +3617,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "16.11.45",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz",
-            "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ==",
+            "version": "16.18.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
+            "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
             "dev": true
         },
         "@types/plist": {
@@ -3036,9 +3650,9 @@
             "optional": true
         },
         "@types/yargs": {
-            "version": "15.0.14",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-            "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+            "version": "17.0.19",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
+            "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
@@ -3061,10 +3675,19 @@
             }
         },
         "7zip-bin": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.0.3.tgz",
-            "integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz",
+            "integrity": "sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==",
             "dev": true
+        },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "requires": {
+                "debug": "4"
+            }
         },
         "ajv": {
             "version": "6.12.6",
@@ -3110,48 +3733,50 @@
             }
         },
         "app-builder-bin": {
-            "version": "3.5.10",
-            "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.5.10.tgz",
-            "integrity": "sha512-Jd+GW68lR0NeetgZDo47PdWBEPdnD+p0jEa7XaxjRC8u6Oo/wgJsfKUkORRgr2NpkD19IFKN50P6JYy04XHFLQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.7.1.tgz",
+            "integrity": "sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw==",
             "dev": true
         },
         "app-builder-lib": {
-            "version": "22.10.3",
-            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.10.3.tgz",
-            "integrity": "sha512-PBHTTGxV1uLVHWKQfw92plrfMo/utH0FVe8v2dFmT/CYKw9u7XuOC0xE8YslUxXmaiG6TuOJaQrII4fXN5VBpQ==",
+            "version": "22.14.13",
+            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.14.13.tgz",
+            "integrity": "sha512-SufmrtxU+D0Tn948fjEwAOlCN9757UXLkzzTWXMwZKR/5hisvgqeeBepWfphMIE6OkDGz0fbzEhL1P2Pty4XMg==",
             "dev": true,
             "requires": {
                 "@develar/schema-utils": "~2.6.5",
-                "7zip-bin": "~5.0.3",
+                "@electron/universal": "1.0.5",
+                "@malept/flatpak-bundler": "^0.4.0",
+                "7zip-bin": "~5.1.1",
                 "async-exit-hook": "^2.0.1",
                 "bluebird-lst": "^1.0.9",
-                "builder-util": "22.10.3",
-                "builder-util-runtime": "8.7.3",
+                "builder-util": "22.14.13",
+                "builder-util-runtime": "8.9.2",
                 "chromium-pickle-js": "^0.2.0",
                 "debug": "^4.3.2",
-                "ejs": "^3.1.5",
-                "electron-publish": "22.10.3",
-                "fs-extra": "^9.0.1",
-                "hosted-git-info": "^3.0.7",
-                "is-ci": "^2.0.0",
-                "isbinaryfile": "^4.0.6",
-                "js-yaml": "^3.14.1",
-                "lazy-val": "^1.0.4",
+                "ejs": "^3.1.6",
+                "electron-osx-sign": "^0.5.0",
+                "electron-publish": "22.14.13",
+                "form-data": "^4.0.0",
+                "fs-extra": "^10.0.0",
+                "hosted-git-info": "^4.0.2",
+                "is-ci": "^3.0.0",
+                "isbinaryfile": "^4.0.8",
+                "js-yaml": "^4.1.0",
+                "lazy-val": "^1.0.5",
                 "minimatch": "^3.0.4",
-                "normalize-package-data": "^3.0.0",
-                "read-config-file": "6.0.0",
+                "read-config-file": "6.2.0",
                 "sanitize-filename": "^1.6.3",
-                "semver": "^7.3.4",
-                "temp-file": "^3.3.7"
+                "semver": "^7.3.5",
+                "temp-file": "^3.4.0"
             },
             "dependencies": {
                 "fs-extra": {
-                    "version": "9.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+                    "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
                     "dev": true,
                     "requires": {
-                        "at-least-node": "^1.0.0",
                         "graceful-fs": "^4.2.0",
                         "jsonfile": "^6.0.1",
                         "universalify": "^2.0.0"
@@ -3185,12 +3810,22 @@
             }
         },
         "argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "asar": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
+            "integrity": "sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "@types/glob": "^7.1.1",
+                "chromium-pickle-js": "^0.2.0",
+                "commander": "^5.0.0",
+                "glob": "^7.1.6",
+                "minimatch": "^3.0.4"
             }
         },
         "assert-plus": {
@@ -3219,6 +3854,12 @@
             "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
             "dev": true
         },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true
+        },
         "at-least-node": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -3235,13 +3876,12 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "bcryptjs": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-            "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+            "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
         },
         "bluebird": {
             "version": "3.7.2",
@@ -3310,10 +3950,38 @@
                 "ieee754": "^1.1.13"
             }
         },
+        "buffer-alloc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+            "dev": true,
+            "requires": {
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
+            }
+        },
+        "buffer-alloc-unsafe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+            "dev": true
+        },
         "buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+            "dev": true
+        },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==",
+            "dev": true
+        },
+        "buffer-fill": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
             "dev": true
         },
         "buffer-from": {
@@ -3323,34 +3991,36 @@
             "dev": true
         },
         "builder-util": {
-            "version": "22.10.3",
-            "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.10.3.tgz",
-            "integrity": "sha512-I9mh78wZaggIF4QkBzMPKhfgGDameyx9TN6Zikl8SKQHiKQNCUzMPUcRXCyCot6iTT8B8blwOM3GhhuU06yv1g==",
+            "version": "22.14.13",
+            "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.14.13.tgz",
+            "integrity": "sha512-oePC/qrrUuerhmH5iaCJzPRAKlSBylrhzuAJmRQClTyWnZUv6jbaHh+VoHMbEiE661wrj2S2aV7/bQh12cj1OA==",
             "dev": true,
             "requires": {
-                "@types/debug": "^4.1.5",
-                "@types/fs-extra": "^9.0.5",
-                "7zip-bin": "~5.0.3",
-                "app-builder-bin": "3.5.10",
+                "@types/debug": "^4.1.6",
+                "@types/fs-extra": "^9.0.11",
+                "7zip-bin": "~5.1.1",
+                "app-builder-bin": "3.7.1",
                 "bluebird-lst": "^1.0.9",
-                "builder-util-runtime": "8.7.3",
-                "chalk": "^4.1.0",
+                "builder-util-runtime": "8.9.2",
+                "chalk": "^4.1.1",
+                "cross-spawn": "^7.0.3",
                 "debug": "^4.3.2",
-                "fs-extra": "^9.0.1",
-                "is-ci": "^2.0.0",
-                "js-yaml": "^3.14.1",
+                "fs-extra": "^10.0.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "is-ci": "^3.0.0",
+                "js-yaml": "^4.1.0",
                 "source-map-support": "^0.5.19",
                 "stat-mode": "^1.0.0",
-                "temp-file": "^3.3.7"
+                "temp-file": "^3.4.0"
             },
             "dependencies": {
                 "fs-extra": {
-                    "version": "9.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+                    "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
                     "dev": true,
                     "requires": {
-                        "at-least-node": "^1.0.0",
                         "graceful-fs": "^4.2.0",
                         "jsonfile": "^6.0.1",
                         "universalify": "^2.0.0"
@@ -3375,9 +4045,9 @@
             }
         },
         "builder-util-runtime": {
-            "version": "8.7.3",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz",
-            "integrity": "sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==",
+            "version": "8.9.2",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.2.tgz",
+            "integrity": "sha512-rhuKm5vh7E0aAmT6i8aoSfEjxzdYEFX7zDApK+eNgOhjofnWb74d9SRJv0H/8nsgOkos0TZ4zxW0P8J4N7xQ2A==",
             "dev": true,
             "requires": {
                 "debug": "^4.3.2",
@@ -3428,9 +4098,9 @@
             "dev": true
         },
         "ci-info": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+            "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
             "dev": true
         },
         "cli-boxes": {
@@ -3451,13 +4121,13 @@
             }
         },
         "cliui": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dev": true,
             "requires": {
                 "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
+                "strip-ansi": "^6.0.1",
                 "wrap-ansi": "^7.0.0"
             }
         },
@@ -3483,6 +4153,33 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "colors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commander": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+            "dev": true
+        },
+        "compare-version": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+            "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
             "dev": true
         },
         "concat-map": {
@@ -3520,6 +4217,17 @@
             "optional": true,
             "requires": {
                 "buffer": "^5.1.0"
+            }
+        },
+        "cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
             }
         },
         "crypto-random-string": {
@@ -3577,6 +4285,12 @@
                 "object-keys": "^1.1.1"
             }
         },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true
+        },
         "detect-node": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -3584,28 +4298,59 @@
             "dev": true,
             "optional": true
         },
-        "dmg-builder": {
-            "version": "22.10.3",
-            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.10.3.tgz",
-            "integrity": "sha512-OB0etdtZJrvx85ah1aoTv5zJ9CXlsepLs9VT6ax6FXxH9aGxJU38AuB8065OPTrj+btMuHQDd0kBVlcs4/BwpA==",
+        "dir-compare": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-2.4.0.tgz",
+            "integrity": "sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==",
             "dev": true,
             "requires": {
-                "app-builder-lib": "22.10.3",
-                "builder-util": "22.10.3",
-                "dmg-license": "^1.0.8",
-                "fs-extra": "^9.0.1",
+                "buffer-equal": "1.0.0",
+                "colors": "1.0.3",
+                "commander": "2.9.0",
+                "minimatch": "3.0.4"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.9.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                    "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": ">= 1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
+            }
+        },
+        "dmg-builder": {
+            "version": "22.14.13",
+            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.14.13.tgz",
+            "integrity": "sha512-xNOugB6AbIRETeU2uID15sUfjdZZcKdxK8xkFnwIggsM00PJ12JxpLNPTjcRoUnfwj3WrPjilrO64vRMwNItQg==",
+            "dev": true,
+            "requires": {
+                "app-builder-lib": "22.14.13",
+                "builder-util": "22.14.13",
+                "builder-util-runtime": "8.9.2",
+                "dmg-license": "^1.0.9",
+                "fs-extra": "^10.0.0",
                 "iconv-lite": "^0.6.2",
-                "js-yaml": "^3.14.1",
-                "sanitize-filename": "^1.6.3"
+                "js-yaml": "^4.1.0"
             },
             "dependencies": {
                 "fs-extra": {
-                    "version": "9.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+                    "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
                     "dev": true,
                     "requires": {
-                        "at-least-node": "^1.0.0",
                         "graceful-fs": "^4.2.0",
                         "jsonfile": "^6.0.1",
                         "universalify": "^2.0.0"
@@ -3656,9 +4401,9 @@
             }
         },
         "dotenv": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-            "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+            "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
             "dev": true
         },
         "dotenv-expand": {
@@ -3683,10 +4428,9 @@
             }
         },
         "electron": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-22.0.0.tgz",
-            "integrity": "sha512-cgRc4wjyM+81A0E8UGv1HNJjL1HBI5cWNh/DUIjzYvoUuiEM0SS0hAH/zaFQ18xOz2ced6Yih8SybpOiOYJhdg==",
+            "version": "git+ssh://git@github.com/castlabs/electron-releases.git#ee6e1f03b8e5097232a12d4e2cb616b8b5cf54ef",
             "dev": true,
+            "from": "electron@github:castlabs/electron-releases#v22.0.0+wvcus",
             "requires": {
                 "@electron/get": "^2.0.0",
                 "@types/node": "^16.11.26",
@@ -3694,34 +4438,31 @@
             }
         },
         "electron-builder": {
-            "version": "22.10.3",
-            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.10.3.tgz",
-            "integrity": "sha512-TNKmeYWrnATD/BBkpmNF03+wAA3+K8DZ6d/F1ipAKCbqeILp4agnr5nrngz+xpl7Y83lhelC1moU4utHNWYhzw==",
+            "version": "22.14.13",
+            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.14.13.tgz",
+            "integrity": "sha512-3fgLxqF2TXVKiUPeg74O4V3l0l3j7ERLazo8sUbRkApw0+4iVAf2BJkHsHMaXiigsgCoEzK/F4/rB5rne/VAnw==",
             "dev": true,
             "requires": {
-                "@types/yargs": "^15.0.11",
-                "app-builder-lib": "22.10.3",
-                "bluebird-lst": "^1.0.9",
-                "builder-util": "22.10.3",
-                "builder-util-runtime": "8.7.3",
-                "chalk": "^4.1.0",
-                "dmg-builder": "22.10.3",
-                "fs-extra": "^9.0.1",
-                "is-ci": "^2.0.0",
-                "lazy-val": "^1.0.4",
-                "read-config-file": "6.0.0",
-                "sanitize-filename": "^1.6.3",
-                "update-notifier": "^5.0.1",
-                "yargs": "^16.2.0"
+                "@types/yargs": "^17.0.1",
+                "app-builder-lib": "22.14.13",
+                "builder-util": "22.14.13",
+                "builder-util-runtime": "8.9.2",
+                "chalk": "^4.1.1",
+                "dmg-builder": "22.14.13",
+                "fs-extra": "^10.0.0",
+                "is-ci": "^3.0.0",
+                "lazy-val": "^1.0.5",
+                "read-config-file": "6.2.0",
+                "update-notifier": "^5.1.0",
+                "yargs": "^17.0.1"
             },
             "dependencies": {
                 "fs-extra": {
-                    "version": "9.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+                    "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
                     "dev": true,
                     "requires": {
-                        "at-least-node": "^1.0.0",
                         "graceful-fs": "^4.2.0",
                         "jsonfile": "^6.0.1",
                         "universalify": "^2.0.0"
@@ -3745,29 +4486,67 @@
                 }
             }
         },
-        "electron-publish": {
-            "version": "22.10.3",
-            "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.10.3.tgz",
-            "integrity": "sha512-NGcgDp0xT92NPB5lGckroz2n5h8Ud53SShmwZoVtCp1W+VOSWn5CVPnXDquzf7pMcZRfo8qoMZrlvUeOlY4oIg==",
+        "electron-osx-sign": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
+            "integrity": "sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==",
             "dev": true,
             "requires": {
-                "@types/fs-extra": "^9.0.5",
-                "bluebird-lst": "^1.0.9",
-                "builder-util": "22.10.3",
-                "builder-util-runtime": "8.7.3",
-                "chalk": "^4.1.0",
-                "fs-extra": "^9.0.1",
-                "lazy-val": "^1.0.4",
-                "mime": "^2.4.6"
+                "bluebird": "^3.5.0",
+                "compare-version": "^0.1.2",
+                "debug": "^2.6.8",
+                "isbinaryfile": "^3.0.2",
+                "minimist": "^1.2.0",
+                "plist": "^3.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "isbinaryfile": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+                    "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-alloc": "^1.2.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+                    "dev": true
+                }
+            }
+        },
+        "electron-publish": {
+            "version": "22.14.13",
+            "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.14.13.tgz",
+            "integrity": "sha512-0oP3QiNj3e8ewOaEpEJV/o6Zrmy2VarVvZ/bH7kyO/S/aJf9x8vQsKVWpsdmSiZ5DJEHgarFIXrnO0ZQf0P9iQ==",
+            "dev": true,
+            "requires": {
+                "@types/fs-extra": "^9.0.11",
+                "builder-util": "22.14.13",
+                "builder-util-runtime": "8.9.2",
+                "chalk": "^4.1.1",
+                "fs-extra": "^10.0.0",
+                "lazy-val": "^1.0.5",
+                "mime": "^2.5.2"
             },
             "dependencies": {
                 "fs-extra": {
-                    "version": "9.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+                    "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
                     "dev": true,
                     "requires": {
-                        "at-least-node": "^1.0.0",
                         "graceful-fs": "^4.2.0",
                         "jsonfile": "^6.0.1",
                         "universalify": "^2.0.0"
@@ -3838,12 +4617,6 @@
             "dev": true,
             "optional": true
         },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
-        },
         "extract-zip": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -3903,14 +4676,25 @@
                     }
                 },
                 "minimatch": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-                    "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+                    "version": "5.1.5",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.5.tgz",
+                    "integrity": "sha512-CI8wwdrll4ehjPAqs8TL8lBPyNnpZlQI02Wn8C1weNz/QbUbjh3OMxgMKSnvqfKFdLlks3EzHB9tO0BqGc3phQ==",
                     "dev": true,
                     "requires": {
                         "brace-expansion": "^2.0.1"
                     }
                 }
+            }
+        },
+        "form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
             }
         },
         "fs-extra": {
@@ -3924,11 +4708,18 @@
                 "universalify": "^0.1.0"
             }
         },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -3955,6 +4746,20 @@
             "dev": true,
             "requires": {
                 "pump": "^3.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "global-agent": {
@@ -4028,11 +4833,18 @@
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
         },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
+            "dev": true
+        },
         "has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -4067,9 +4879,9 @@
             "dev": true
         },
         "hosted-git-info": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
-            "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
             "dev": true,
             "requires": {
                 "lru-cache": "^6.0.0"
@@ -4081,6 +4893,17 @@
             "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
             "dev": true
         },
+        "http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dev": true,
+            "requires": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
         "http2-wrapper": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
@@ -4089,6 +4912,16 @@
             "requires": {
                 "quick-lru": "^5.1.1",
                 "resolve-alpn": "^1.0.0"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
             }
         },
         "iconv-corefoundation": {
@@ -4130,6 +4963,22 @@
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true
         },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
         "ini": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
@@ -4137,21 +4986,12 @@
             "dev": true
         },
         "is-ci": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+            "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
             "dev": true,
             "requires": {
-                "ci-info": "^2.0.0"
-            }
-        },
-        "is-core-module": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-            "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-            "dev": true,
-            "requires": {
-                "has": "^1.0.3"
+                "ci-info": "^3.2.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -4206,6 +5046,12 @@
             "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
             "dev": true
         },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
+        },
         "jake": {
             "version": "10.8.5",
             "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
@@ -4219,13 +5065,12 @@
             }
         },
         "js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
             }
         },
         "json-buffer": {
@@ -4248,9 +5093,9 @@
             "optional": true
         },
         "json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true
         },
         "jsonfile": {
@@ -4284,6 +5129,12 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
             "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+            "dev": true
+        },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "lowercase-keys": {
@@ -4326,6 +5177,21 @@
             "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
             "dev": true
         },
+        "mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.52.0"
+            }
+        },
         "mimic-response": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -4342,9 +5208,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
         },
         "mkdirp": {
             "version": "0.5.6",
@@ -4366,38 +5232,6 @@
             "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
             "dev": true,
             "optional": true
-        },
-        "normalize-package-data": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-            "dev": true,
-            "requires": {
-                "hosted-git-info": "^4.0.1",
-                "is-core-module": "^2.5.0",
-                "semver": "^7.3.4",
-                "validate-npm-package-license": "^3.0.1"
-            },
-            "dependencies": {
-                "hosted-git-info": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-                    "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
-            }
         },
         "normalize-url": {
             "version": "6.1.0",
@@ -4566,6 +5400,18 @@
                 }
             }
         },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true
+        },
+        "path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true
+        },
         "pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -4577,7 +5423,6 @@
             "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
             "integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "base64-js": "^1.5.1",
                 "xmlbuilder": "^15.1.1"
@@ -4606,9 +5451,9 @@
             }
         },
         "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
+            "integrity": "sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==",
             "dev": true
         },
         "pupa": {
@@ -4647,15 +5492,15 @@
             }
         },
         "read-config-file": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.0.0.tgz",
-            "integrity": "sha512-PHjROSdpceKUmqS06wqwP92VrM46PZSTubmNIMJ5DrMwg1OgenSTSEHIkCa6TiOJ+y/J0xnG1fFwG3M+Oi1aNA==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.2.0.tgz",
+            "integrity": "sha512-gx7Pgr5I56JtYz+WuqEbQHj/xWo+5Vwua2jhb1VwM4Wid5PqYmZ4i00ZB0YEGIfkVBsCv9UrjgyqCiQfS/Oosg==",
             "dev": true,
             "requires": {
-                "dotenv": "^8.2.0",
+                "dotenv": "^9.0.2",
                 "dotenv-expand": "^5.1.0",
-                "js-yaml": "^3.13.1",
-                "json5": "^2.1.2",
+                "js-yaml": "^4.1.0",
+                "json5": "^2.2.0",
                 "lazy-val": "^1.0.4"
             }
         },
@@ -4698,6 +5543,15 @@
                 "lowercase-keys": "^2.0.0"
             }
         },
+        "rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
         "roarr": {
             "version": "2.15.4",
             "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -4711,15 +5565,6 @@
                 "json-stringify-safe": "^5.0.1",
                 "semver-compare": "^1.0.0",
                 "sprintf-js": "^1.1.2"
-            },
-            "dependencies": {
-                "sprintf-js": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-                    "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "safer-buffer": {
@@ -4775,6 +5620,21 @@
                 "type-fest": "^0.13.1"
             }
         },
+        "shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^3.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true
+        },
         "signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -4816,43 +5676,12 @@
                 "source-map": "^0.6.0"
             }
         },
-        "spdx-correct": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-            "dev": true,
-            "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-exceptions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-            "dev": true
-        },
-        "spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-license-ids": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-            "dev": true
-        },
         "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+            "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+            "dev": true,
+            "optional": true
         },
         "stat-mode": {
             "version": "1.0.0",
@@ -4943,6 +5772,24 @@
                 }
             }
         },
+        "tmp": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+            "dev": true,
+            "requires": {
+                "rimraf": "^3.0.0"
+            }
+        },
+        "tmp-promise": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+            "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+            "dev": true,
+            "requires": {
+                "tmp": "^0.2.0"
+            }
+        },
         "to-readable-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
@@ -5011,6 +5858,21 @@
                 "xdg-basedir": "^4.0.0"
             },
             "dependencies": {
+                "ci-info": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+                    "dev": true
+                },
+                "is-ci": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+                    "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^2.0.0"
+                    }
+                },
                 "semver": {
                     "version": "7.3.8",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -5046,16 +5908,6 @@
             "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
             "dev": true
         },
-        "validate-npm-package-license": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
-            "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-            }
-        },
         "verror": {
             "version": "1.10.1",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
@@ -5066,6 +5918,15 @@
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
                 "extsprintf": "^1.2.0"
+            }
+        },
+        "which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
             }
         },
         "widest-line": {
@@ -5116,8 +5977,7 @@
             "version": "15.1.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
             "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "y18n": {
             "version": "5.0.8",
@@ -5132,24 +5992,24 @@
             "dev": true
         },
         "yargs": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "version": "17.6.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+            "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
             "dev": true,
             "requires": {
-                "cliui": "^7.0.2",
+                "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
-                "string-width": "^4.2.0",
+                "string-width": "^4.2.3",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^20.2.2"
+                "yargs-parser": "^21.1.1"
             }
         },
         "yargs-parser": {
-            "version": "20.2.9",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true
         },
         "yauzl": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "dist": "electron-builder"
     },
     "devDependencies": {
-        "electron": "^22.0.0",
+        "electron": "github:castlabs/electron-releases#v22.0.0+wvcus",
         "electron-builder": "^22.10.3"
     },
     "dependencies": {
@@ -22,6 +22,9 @@
         "appId": "tech.liveg.gshell",
         "productName": "gShell",
         "copyright": "Copyright © LiveG. All Rights Reserved.",
+        "electronDownload": {
+            "mirror": "https://github.com/castlabs/electron-releases/releases/download/v"
+        },
         "extraResources": [
             {
                 "from": "shell",
@@ -37,8 +40,7 @@
                 {
                     "target": "AppImage",
                     "arch": [
-                        "x64",
-                        "armv7l"
+                        "x64"
                     ]
                 }
             ],

--- a/src/main.js
+++ b/src/main.js
@@ -59,6 +59,8 @@ electron.app.on("ready", function() {
         return device.init(flags.deviceDescriptionLocation || undefined);
     }).then(function() {
         return system.getScreenResolution();
+    }).then(function() {
+        return electron.components.whenReady();
     }).then(function(resolution) {
         exports.window = new electron.BrowserWindow({
             width: resolution.width,


### PR DESCRIPTION
Not my first choice of things to implement (with DRM being a bit of a silly thing that is easy to circumvent with capture cards etc.) but is something that will be necessary at some point for those who want to use various popular streaming services.

Currently is not supported on `armv7l`. Also, weirdly, gShell can't be started from the VSCode terminal using this.